### PR TITLE
Remove metaprogramming and favour composition over inheritance for Phones

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Pronounce.how_do_i_pronounce('monkeys')
 Pronounce.symbols
 => ["AA", "AA0", "AA1", "AA2", "AE", "AE0", "AE1", "AE2", "AH", "AH0", "AH1", "AH2", "AO", "AO0", "AO1", "AO2", "AW", "AW0", "AW1", "AW2", "AY", "AY0", "AY1", "AY2", "B", "CH", "D", "DH", "EH", "EH0", "EH1", "EH2", "ER", "ER0", "ER1", "ER2", "EY", "EY0", "EY1", "EY2", "F", "G", "HH", "IH", "IH0", "IH1", "IH2", "IY", "IY0", "IY1", "IY2", "JH", "K", "L", "M", "N", "NG", "OW", "OW0", "OW1", "OW2", "OY", "OY0", "OY1", "OY2", "P", "R", "S", "SH", "T", "TH", "UH", "UH0", "UH1", "UH2", "UW", "UW0", "UW1", "UW2", "V", "W", "Y", "Z", "ZH"]
 
-Pronounce::Phone.all
-=> {Pronounce::AA=>vowel, Pronounce::AE=>vowel, Pronounce::AH=>vowel, Pronounce::AO=>vowel, Pronounce::AW=>vowel, Pronounce::AY=>vowel, Pronounce::B=>stop, Pronounce::CH=>affricate, Pronounce::D=>stop, Pronounce::DH=>fricative, Pronounce::EH=>vowel, Pronounce::ER=>vowel, Pronounce::EY=>vowel, Pronounce::F=>fricative, Pronounce::G=>stop, Pronounce::HH=>aspirate, Pronounce::IH=>vowel, Pronounce::IY=>vowel, Pronounce::JH=>affricate, Pronounce::K=>stop, Pronounce::L=>liquid, Pronounce::M=>nasal, Pronounce::N=>nasal, Pronounce::NG=>nasal, Pronounce::OW=>vowel, Pronounce::OY=>vowel, Pronounce::P=>stop, Pronounce::R=>liquid, Pronounce::S=>fricative, Pronounce::SH=>fricative, Pronounce::T=>stop, Pronounce::TH=>fricative, Pronounce::UH=>vowel, Pronounce::UW=>vowel, Pronounce::V=>fricative, Pronounce::W=>semivowel, Pronounce::Y=>semivowel, Pronounce::Z=>fricative, Pronounce::ZH=>fricative}
+Pronounce::PhoneType.all
+=> {AA=>vowel, AE=>vowel, AH=>vowel, AO=>vowel, AW=>vowel, AY=>vowel, B=>stop, CH=>affricate, D=>stop, DH=>fricative, EH=>vowel, ER=>vowel, EY=>vowel, F=>fricative, G=>stop, HH=>aspirate, IH=>vowel, IY=>vowel, JH=>affricate, K=>stop, L=>liquid, M=>nasal, N=>nasal, NG=>nasal, OW=>vowel, OY=>vowel, P=>stop, R=>liquid, S=>fricative, SH=>fricative, T=>stop, TH=>fricative, UH=>vowel, UW=>vowel, V=>fricative, W=>semivowel, Y=>semivowel, Z=>fricative, ZH=>fricative}
 
 ```
 

--- a/lib/articulation.rb
+++ b/lib/articulation.rb
@@ -8,12 +8,6 @@ module Pronounce
     end
 
     class << self
-      def [](name)
-        NAMED_ARTICULATIONS[name]
-      end
-
-      private
-
       NAMED_ARTICULATIONS = {
         aspirate:  Articulation.new(:aspirate, 0), # Dogil 1992, p393
         stop:      Articulation.new(:stop, 1),
@@ -24,6 +18,12 @@ module Pronounce
         semivowel: Articulation.new(:semivowel, 6),
         vowel:     Articulation.new(:vowel, 7)
       }
+
+      def [](name)
+        NAMED_ARTICULATIONS[name]
+      end
+
+      protected :new
 
     end
 

--- a/lib/data_reader.rb
+++ b/lib/data_reader.rb
@@ -4,7 +4,7 @@ module Pronounce
     DATA_DIR = File.dirname(__FILE__) + '/../data'
 
     class << self
-      def phones
+      def phone_types
         File.readlines "#{DATA_DIR}/cmudict/cmudict.#{CMUDICT_VERSION}.phones"
       end
 

--- a/lib/phone_type.rb
+++ b/lib/phone_type.rb
@@ -1,0 +1,62 @@
+require 'articulation'
+require 'data_reader'
+
+module Pronounce
+  class PhoneType
+    SHORT_VOWELS = %w[AE AH EH IH UH]
+
+    include Comparable
+
+    class << self
+      def [](name)
+        types[name]
+      end
+
+      def all
+        types.values.each_with_object({}) {|type, all|
+          all[type] = type.articulation
+        }
+      end
+
+      protected :new
+
+      private
+
+      def types
+        @types ||= parse_types
+      end
+
+      def parse_types
+        DataReader.phone_types.each_with_object({}) {|line, types|
+          name, articulation = *line.strip.split("\t")
+          types[name] = PhoneType.new name, articulation
+        }
+      end
+
+    end
+
+    attr_reader :articulation, :name
+
+    def initialize(name, articulation)
+      @name = name
+      @articulation = Articulation[articulation.to_sym]
+    end
+
+    def <=>(type)
+      self.articulation <=> type.articulation if PhoneType === type
+    end
+
+    def inspect
+      name
+    end
+
+    def short?
+      SHORT_VOWELS.include? name
+    end
+
+    def syllabic?
+      articulation.syllabic?
+    end
+
+  end
+end

--- a/lib/syllable_rules/english.rb
+++ b/lib/syllable_rules/english.rb
@@ -1,6 +1,6 @@
 module Pronounce::SyllableRules
   rule :en, '/ng/ cannot start a syllable' do |context|
-    false if ::Pronounce::NG === context.current_phone
+    false if context.current_phone.eql? ::Pronounce::Phone.new 'NG'
   end
 
   # http://en.wikipedia.org/wiki/Syllable_weight#Linguistics

--- a/lib/word.rb
+++ b/lib/word.rb
@@ -8,7 +8,7 @@ require 'syllable_rules/english'
 module Pronounce
   class Word
     def initialize(raw_phones)
-      @phones = raw_phones.map {|symbol| Phone.create symbol }
+      @phones = raw_phones.map {|symbol| Phone.new symbol }
     end
 
     def syllables

--- a/spec/articulation_spec.rb
+++ b/spec/articulation_spec.rb
@@ -3,6 +3,10 @@ require 'articulation'
 
 module Pronounce
   describe Articulation do
+    it 'does not allow creation of new instances' do
+      expect { Articulation.new }.to raise_error NoMethodError
+    end
+
     describe '#<=>' do
       it 'is based on sonority' do
         expect(Articulation[:stop]).to be < Articulation[:fricative]
@@ -25,11 +29,11 @@ module Pronounce
 
     describe '#syllabic?' do
       it 'is true for vowels' do
-        expect(Articulation[:vowel].syllabic?).to be_true
+        expect(Articulation[:vowel].syllabic?).to be true
       end
 
       it 'is false for consonants' do
-        expect(Articulation[:affricate].syllabic?).to be_false
+        expect(Articulation[:affricate].syllabic?).to be false
       end
     end
 

--- a/spec/data_reader_spec.rb
+++ b/spec/data_reader_spec.rb
@@ -4,7 +4,7 @@ module Pronounce
   describe DataReader do
     subject { DataReader }
 
-    its(:phones) { should include "AA\tvowel\n" }
+    its(:phone_types) { should include "AA\tvowel\n" }
     its(:pronunciations) { should include ";;; # CMUdict  --  Major Version: 0.07a [102007]\n" }
     its(:symbols) { should include "AA\r\n" }
 

--- a/spec/phone_spec.rb
+++ b/spec/phone_spec.rb
@@ -3,96 +3,95 @@ require 'phone'
 
 module Pronounce
   describe Phone do
-    describe '.all' do
-      it 'lists all English phones' do
-        Phone.all.should == {
-          AA => Articulation[:vowel],     L  => Articulation[:liquid],
-          AE => Articulation[:vowel],     M  => Articulation[:nasal],
-          AH => Articulation[:vowel],     N  => Articulation[:nasal],
-          AO => Articulation[:vowel],     NG => Articulation[:nasal],
-          AW => Articulation[:vowel],     OW => Articulation[:vowel],
-          AY => Articulation[:vowel],     OY => Articulation[:vowel],
-          B  => Articulation[:stop],      P  => Articulation[:stop],
-          CH => Articulation[:affricate], R  => Articulation[:liquid],
-          D  => Articulation[:stop],      S  => Articulation[:fricative],
-          DH => Articulation[:fricative], SH => Articulation[:fricative],
-          EH => Articulation[:vowel],     T  => Articulation[:stop],
-          ER => Articulation[:vowel],     TH => Articulation[:fricative],
-          EY => Articulation[:vowel],     UH => Articulation[:vowel],
-          F  => Articulation[:fricative], UW => Articulation[:vowel],
-          G  => Articulation[:stop],      V  => Articulation[:fricative],
-          HH => Articulation[:aspirate],  W  => Articulation[:semivowel],
-          IH => Articulation[:vowel],     Y  => Articulation[:semivowel],
-          IY => Articulation[:vowel],     Z  => Articulation[:fricative],
-          JH => Articulation[:affricate], ZH => Articulation[:fricative],
-          K  => Articulation[:stop]
-        }
-      end
-    end
-
-    describe '.create' do
-      it 'creates an instance of the matching type of Phone' do
-        Phone.create('OY2').should be_an_instance_of OY
-      end
-
-      it 'fails if there is no matching, legal phone' do
-        expect { Phone.create('ZA') }.to raise_error NameError
+    describe '.new' do
+      it 'fails if symbol is not in Pronounce.symbols' do
+        expect { Phone.new 'ZA' }.to raise_error ArgumentError
       end
     end
 
     describe '#<=>' do
       it 'is based on sonority' do
-        Phone.create('AH').should == Phone.create('UW')
-        Phone.create('P').should be <  Phone.create('CH')
-        Phone.create('F').should be <= Phone.create('Z')
-        Phone.create('M').should be >= Phone.create('N')
-        Phone.create('W').should be >  Phone.create('R')
+        expect(Phone.new 'AH').to eq Phone.new('UW')
+        expect(Phone.new 'P').to be <  Phone.new('CH')
+        expect(Phone.new 'F').to be <= Phone.new('Z')
+        expect(Phone.new 'M').to be >= Phone.new('N')
+        expect(Phone.new 'W').to be >  Phone.new('R')
       end
 
       it 'fails when trying to compare to a non-Phone' do
-        expect { Phone.create('P') < 'CH' }.to raise_error ArgumentError
+        expect { Phone.new('P') < 'CH' }.to raise_error ArgumentError
       end
     end
 
     describe '#eql?' do
-      subject { Phone.create('AH') }
+      let(:phone) { Phone.new 'AH' }
 
-      it 'is true for an instance of the same Phone' do
-        should eql Phone.create('AH')
+      it 'is true for an instance of the same phone' do
+        expect(phone).to eql Phone.new('AH')
       end
 
-      it 'is false for an instance of a different Phone' do
-        should_not eql Phone.create('UW')
+      it 'is false for an instance of a different phone' do
+        expect(phone).to_not eql Phone.new('UW')
       end
 
       it 'is false for a non-Phone' do
-        should_not eql 'AH'
+        expect(phone).to_not eql 'AH'
+      end
+    end
+
+    describe '#hash' do
+      let(:hash) { Phone.new('AH').hash }
+
+      it 'is the same for an instance of the same phone' do
+        expect(hash).to eq Phone.new('AH').hash
+      end
+
+      it 'is different for an instance of a different phone' do
+        expect(hash).to_not eq Phone.new('UW').hash
+      end
+
+      it 'is different for a non-Phone' do
+        expect(hash).to_not eq 'AH'.hash
+      end
+    end
+
+    describe '#short?' do
+      it 'is true for short vowels' do
+        expect(Phone.new('AE').short?).to be true
+      end
+
+      it 'is false for long vowels' do
+        expect(Phone.new('AY').short?).to be false
+      end
+
+      it 'is false for consonants' do
+        expect(Phone.new('ZH').short?).to be false
       end
     end
 
     describe '#stress' do
       it 'is an integer' do
-        Phone.create('OY2').stress.should == 2
+        expect(Phone.new('OY2').stress).to be 2
       end
 
       it 'is nil for consonants' do
-        Phone.create('ZH').stress.should be_nil
+        expect(Phone.new('ZH').stress).to be_nil
       end
     end
 
     describe '#syllabic?' do
       it 'is true for vowels' do
-        Phone.create('AA').syllabic?.should be_true
+        expect(Phone.new('AA').syllabic?).to be true
       end
 
       it 'is false for consonants' do
-        Phone.create('ZH').syllabic?.should be_false
+        expect(Phone.new('ZH').syllabic?).to be false
       end
     end
 
     describe '#to_s' do
-      it 'includes the symbol and stress' do
-        Phone.create('OY2').to_s.should == 'OY2'
+      it 'includes the type and stress' do
+        expect(Phone.new('OY2').to_s).to eq 'OY2'
       end
     end
 

--- a/spec/phone_type_spec.rb
+++ b/spec/phone_type_spec.rb
@@ -1,0 +1,100 @@
+require 'phone_type'
+
+module Pronounce
+  describe PhoneType do
+    describe '.all' do
+      it 'lists all English phones' do
+        expect(PhoneType.all).to eq({
+          PhoneType['AA'] => Articulation[:vowel],
+          PhoneType['AE'] => Articulation[:vowel],
+          PhoneType['AH'] => Articulation[:vowel],
+          PhoneType['AO'] => Articulation[:vowel],
+          PhoneType['AW'] => Articulation[:vowel],
+          PhoneType['AY'] => Articulation[:vowel],
+          PhoneType['B']  => Articulation[:stop],
+          PhoneType['CH'] => Articulation[:affricate],
+          PhoneType['D']  => Articulation[:stop],
+          PhoneType['DH'] => Articulation[:fricative],
+          PhoneType['EH'] => Articulation[:vowel],
+          PhoneType['ER'] => Articulation[:vowel],
+          PhoneType['EY'] => Articulation[:vowel],
+          PhoneType['F']  => Articulation[:fricative],
+          PhoneType['G']  => Articulation[:stop],
+          PhoneType['HH'] => Articulation[:aspirate],
+          PhoneType['IH'] => Articulation[:vowel],
+          PhoneType['IY'] => Articulation[:vowel],
+          PhoneType['JH'] => Articulation[:affricate],
+          PhoneType['K']  => Articulation[:stop],
+          PhoneType['L']  => Articulation[:liquid],
+          PhoneType['M']  => Articulation[:nasal],
+          PhoneType['N']  => Articulation[:nasal],
+          PhoneType['NG'] => Articulation[:nasal],
+          PhoneType['OW'] => Articulation[:vowel],
+          PhoneType['OY'] => Articulation[:vowel],
+          PhoneType['P']  => Articulation[:stop],
+          PhoneType['R']  => Articulation[:liquid],
+          PhoneType['S']  => Articulation[:fricative],
+          PhoneType['SH'] => Articulation[:fricative],
+          PhoneType['T']  => Articulation[:stop],
+          PhoneType['TH'] => Articulation[:fricative],
+          PhoneType['UH'] => Articulation[:vowel],
+          PhoneType['UW'] => Articulation[:vowel],
+          PhoneType['V']  => Articulation[:fricative],
+          PhoneType['W']  => Articulation[:semivowel],
+          PhoneType['Y']  => Articulation[:semivowel],
+          PhoneType['Z']  => Articulation[:fricative],
+          PhoneType['ZH'] => Articulation[:fricative]
+        })
+      end
+    end
+
+    it 'does not allow creation of new instances' do
+      expect { PhoneType.new }.to raise_error NoMethodError
+    end
+
+    describe '#<=>' do
+      it 'is based on sonority' do
+        expect(PhoneType['AH']).to eq PhoneType['UW']
+        expect(PhoneType['P']).to be <  PhoneType['CH']
+        expect(PhoneType['F']).to be <= PhoneType['Z']
+        expect(PhoneType['M']).to be >= PhoneType['N']
+        expect(PhoneType['W']).to be >  PhoneType['R']
+      end
+
+      it 'fails when trying to compare to a non-PhoneType object' do
+        expect { PhoneType['P'] < 'CH' }.to raise_error ArgumentError
+      end
+    end
+
+    describe '#inspect' do
+      it 'returns the name' do
+        expect(PhoneType['AE'].inspect).to eq 'AE'
+      end
+    end
+
+    describe '#short?' do
+      it 'is true for short vowels' do
+        expect(PhoneType['AE'].short?).to be true
+      end
+
+      it 'is false for long vowels' do
+        expect(PhoneType['AY'].short?).to be false
+      end
+
+      it 'is false for consonants' do
+        expect(PhoneType['ZH'].short?).to be false
+      end
+    end
+
+    describe '#syllabic?' do
+      it 'is true for vowels' do
+        expect(PhoneType['AA'].syllabic?).to be true
+      end
+
+      it 'is false for consonants' do
+        expect(PhoneType['ZH'].syllabic?).to be false
+      end
+    end
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 require 'phone'
 require 'syllable'
 
-def make_phones(phones)
-  phones.map {|phone| Pronounce::Phone.create phone }
+def make_phones(symbols)
+  symbols.map {|symbol| Pronounce::Phone.new symbol }
 end
 
-def make_syllable(phones)
-  Pronounce::Syllable.new(make_phones(phones))
+def make_syllable(symbols)
+  Pronounce::Syllable.new(make_phones(symbols))
 end

--- a/spec/syllabification_context_spec.rb
+++ b/spec/syllabification_context_spec.rb
@@ -5,16 +5,16 @@ module Pronounce
   describe SyllabificationContext do
     subject { SyllabificationContext.new syllables, phones, index }
 
-    let(:syllables) { [make_syllable(%w{AE0 N})] }
-    let(:phones) { make_phones %w{AE0 N D R AA1 M AH0 D AH0} } # Andromeda
+    let(:syllables) { [make_syllable(%w[AE0 N])] }
+    let(:phones) { make_phones %w[AE0 N D R AA1 M AH0 D AH0] } # Andromeda
 
     context 'for the first phone' do
       let(:index) { 0 }
 
       it { should be_word_beginning }
       it { should_not be_word_end }
-      its(:current_phone) { should be_an AE }
-      its(:next_phone) { should be_an N }
+      its(:current_phone) { should eq Phone.new 'AE' }
+      its(:next_phone) { should eq Phone.new 'N' }
       its(:previous_phone) { should be_nil }
     end
 
@@ -23,9 +23,9 @@ module Pronounce
 
       it { should_not be_word_beginning }
       it { should_not be_word_end }
-      its(:current_phone) { should be_an N }
-      its(:next_phone) { should be_a D }
-      its(:previous_phone) { should be_an AE }
+      its(:current_phone) { should eq Phone.new 'N' }
+      its(:next_phone) { should eq Phone.new 'D' }
+      its(:previous_phone) { should eq Phone.new 'AE' }
     end
 
     context 'for the last phone' do
@@ -33,16 +33,16 @@ module Pronounce
 
       it { should_not be_word_beginning }
       it { should be_word_end }
-      its(:current_phone) { should be_a AH }
+      its(:current_phone) { should eq Phone.new 'AH' }
       its(:next_phone) { should be_nil }
-      its(:previous_phone) { should be_an D }
+      its(:previous_phone) { should eq Phone.new 'D' }
     end
 
     describe '#pending_syllable' do
       let(:index) { 4 }
 
       it 'is everything between the completed syllables and the current phone' do
-        expect(subject.pending_syllable.to_strings).to eq %w{D R}
+        expect(subject.pending_syllable.to_strings).to eq %w[D R]
       end
     end
 
@@ -52,7 +52,7 @@ module Pronounce
         let(:index) { 2 }
 
         it 'is true' do
-          expect(subject.previous_phone_in_coda?).to eq true
+          expect(subject.previous_phone_in_coda?).to be true
         end
       end
 
@@ -60,7 +60,7 @@ module Pronounce
         let(:index) { 4 }
 
         it 'is false' do
-          expect(subject.previous_phone_in_coda?).to eq false
+          expect(subject.previous_phone_in_coda?).to be false
         end
       end
     end
@@ -70,7 +70,7 @@ module Pronounce
         let(:index) { 4 }
 
         it 'is true' do
-          expect(subject.previous_phone_in_onset?).to eq true
+          expect(subject.previous_phone_in_onset?).to be true
         end
       end
 
@@ -78,20 +78,20 @@ module Pronounce
         let(:index) { 6 }
 
         it 'is false' do
-          expect(subject.previous_phone_in_onset?).to eq false
+          expect(subject.previous_phone_in_onset?).to be false
         end
       end
     end
 
     describe '#sonority_trough?' do
       let(:syllables) { [] }
-      let(:phones) { make_phones %w{B AE1 K P AE2 K ER0} } # backpacker
+      let(:phones) { make_phones %w[B AE1 K P AE2 K ER0] } # backpacker
 
       context 'when current phone is less than next and previous' do
         let(:index) { 5 }
 
         it 'is true' do
-          expect(subject.sonority_trough?).to eq true
+          expect(subject.sonority_trough?).to be true
         end
       end
 
@@ -99,7 +99,7 @@ module Pronounce
         let(:index) { 3 }
 
         it 'is true' do
-          expect(subject.sonority_trough?).to eq true
+          expect(subject.sonority_trough?).to be true
         end
       end
     end

--- a/spec/syllable_spec.rb
+++ b/spec/syllable_spec.rb
@@ -3,15 +3,15 @@ require 'syllable'
 
 module Pronounce
   describe Syllable do
-    subject { make_syllable %w{AE1 D Z} }
+    subject { make_syllable %w[AE1 D Z] }
 
-    its(:to_strings) { should == %w{AE1 D Z} }
+    its(:to_strings) { should == %w[AE1 D Z] }
     its(:length) { should == 3 }
 
     context 'with a nucleus and coda' do
       describe '#coda_contains' do
         it 'part of the coda is true' do
-          expect(subject.coda_contains? Phone.create('D')).to eq true
+          expect(subject.coda_contains? Phone.new('D')).to be true
         end
       end
 
@@ -20,24 +20,24 @@ module Pronounce
 
     context 'with no coda and a nucleus' do
       context 'which is short' do
-        subject { make_syllable %w{B IH1} }
+        subject { make_syllable %w[B IH1] }
 
         its(:light?) { should == true }
       end
 
       context 'which is long' do
-        subject { make_syllable %w{B AY1} }
+        subject { make_syllable %w[B AY1] }
 
         its(:light?) { should == false }
       end
     end
 
     context 'with an onset only (pending syllables only)' do
-      subject { make_syllable %w{N} }
+      subject { make_syllable %w[N] }
 
       describe '#coda_contains' do
         it 'part of the onset is false' do
-          expect(subject.coda_contains? Phone.create('N')).to eq false
+          expect(subject.coda_contains? Phone.new('N')).to be false
         end
       end
     end
@@ -47,7 +47,7 @@ module Pronounce
     end
 
     context 'with an unstressed vowel' do
-      subject { make_syllable %w{AH0 N} }
+      subject { make_syllable %w[AH0 N] }
       its(:stressed?) { should == false }
     end
 


### PR DESCRIPTION
In #3 I decided to load the data in the phones file as functions that create instances of Phone with different common bits of data. I did that in https://github.com/gwagener/pronounce/compare/master...phone_functions. However, while coding that I realised that there was no need for functions when we were only dealing with static data. I first thought about having a hash with the type name to articulation association, but that isn't OO and also isn't extensible if I wanted to add something to phone types like... voicing, not saying that's coming ;)

This makes Phone smaller, but adds a lot of code in total. More of that code is also becoming delegation, Phone delegates comparability and syllabicity to PhoneType which delegates them to Articulation. That's possibly just the way things have evolved, but I tried to split things out into classes so they had appropriate responsibilities.

I do like the parallels between PhoneType and Articulation which is something I was thinking of in my comments on #3.
